### PR TITLE
fix: avoid duplicate toast listeners

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -182,7 +182,10 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+    // The listener should only be registered once on mount.
+    // Using an empty dependency array prevents duplicating listeners
+    // whenever the toast state updates.
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- ensure toast state listener only registers once

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for Next.js ESLint config)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6891e7e1704c8333ae67813837f27833