### PR TITLE
Fix hero section to display images

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,16 +27,26 @@ async function getHeroData() {
       throw new Error(`Failed to fetch: ${res.status}`);
     }
     const response = await res.json();
-    const attributes = response?.data?.attributes;
+    const data = response?.data;
+    const attributes = data?.attributes ?? data;
 
     const getUrl = (media: any) => {
-      if (!media?.data?.attributes?.url) return null;
-      return `${strapiBaseUrl}${media.data.attributes.url}`;
+      if (!media) return null;
+      if (media.url) return `${strapiBaseUrl}${media.url}`;
+      if (media.data?.attributes?.url) return `${strapiBaseUrl}${media.data.attributes.url}`;
+      if (media.data?.url) return `${strapiBaseUrl}${media.data.url}`;
+      return null;
     };
-    
+
     const getUrls = (media: any) => {
-      if (!media?.data) return [];
-      return media.data.map((img: any) => `${strapiBaseUrl}${img?.attributes?.url}`);
+      if (!media) return [];
+      if (Array.isArray(media)) {
+        return media.map(item => getUrl(item)).filter(Boolean);
+      }
+      if (Array.isArray(media.data)) {
+        return media.data.map((img: any) => getUrl(img)).filter(Boolean);
+      }
+      return [];
     };
 
     return {

--- a/src/components/home-client.tsx
+++ b/src/components/home-client.tsx
@@ -30,7 +30,7 @@ export default function HomeClient({ heroData, featuredProperties, testimonials,
     <div className="flex flex-col">
       {/* Hero Section */}
       <section className="relative h-screen w-full overflow-hidden text-white">
-        {/* Background content */}
+        {/* Background content with video > images > placeholder fallback */}
         {heroData.desktopVideo ? (
           <video
             src={heroData.desktopVideo}
@@ -40,14 +40,14 @@ export default function HomeClient({ heroData, featuredProperties, testimonials,
             playsInline
             className="absolute inset-0 w-full h-full object-cover z-0"
           />
-        ) : (
+        ) : heroData.desktopImages.length > 0 ? (
           <Carousel
             className="absolute inset-0 w-full h-full z-0"
             plugins={[Autoplay({ delay: 5000, stopOnInteraction: false })]}
             opts={{ loop: true }}
           >
             <CarouselContent className="h-full">
-              {(heroData.desktopImages.length > 0 ? heroData.desktopImages : ['https://placehold.co/1920x1080/000000/FFF?text=Modern+Architecture']).map((url, i) => (
+              {heroData.desktopImages.map((url, i) => (
                 <CarouselItem key={i} className="relative h-full">
                   <Image
                     src={url}
@@ -60,6 +60,14 @@ export default function HomeClient({ heroData, featuredProperties, testimonials,
               ))}
             </CarouselContent>
           </Carousel>
+        ) : (
+          <Image
+            src="https://placehold.co/1920x1080/000000/FFF?text=Modern+Architecture"
+            alt="Hero placeholder image"
+            fill
+            className="absolute inset-0 w-full h-full object-cover z-0"
+            priority
+          />
         )}
 
         {/* Overlay */}


### PR DESCRIPTION
## Summary
- parse hero media objects regardless of Strapi response shape
- ensure hero section falls back from video to images to placeholder

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689202b213bc8333a16e042a49444309