### PR TITLE
Fix hero section to display images

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,6 @@
 
 import HomeClient from '@/components/home-client';
 import { properties } from '@/data/properties';
-import { TestimonialCard } from '@/components/testimonial-card';
-import { AreaGuideCard } from '@/components/area-guide-card';
 
 const strapiBaseUrl = 'https://cms.authenticholidayhomes.ae';
 
@@ -22,30 +20,44 @@ const areaGuides = [
 
 async function getHeroData() {
   try {
-    const res = await fetch(`${strapiBaseUrl}/api/homepage?populate=*`, { cache: 'no-store' });
+    const res = await fetch(`${strapiBaseUrl}/api/homepage?populate[Hero][populate]=*`, { cache: 'no-store' });
     if (!res.ok) {
       throw new Error(`Failed to fetch: ${res.status}`);
     }
     const response = await res.json();
-    const attributes = response?.data?.attributes;
+    const data = response?.data;
+    const attributes = data?.attributes ?? data;
+    const hero = Array.isArray(attributes?.Hero) ? attributes.Hero[0] : attributes;
 
     const getUrl = (media: any) => {
-      if (!media?.data?.attributes?.url) return null;
-      return `${strapiBaseUrl}${media.data.attributes.url}`;
+      if (!media) return null;
+      const item = Array.isArray(media) ? media[0] : media;
+      if (!item) return null;
+      if (item.url) return `${strapiBaseUrl}${item.url}`;
+      if (item.attributes?.url) return `${strapiBaseUrl}${item.attributes.url}`;
+      if (item.data?.attributes?.url) return `${strapiBaseUrl}${item.data.attributes.url}`;
+      if (item.data?.url) return `${strapiBaseUrl}${item.data.url}`;
+      return null;
     };
-    
+
     const getUrls = (media: any) => {
-      if (!media?.data) return [];
-      return media.data.map((img: any) => `${strapiBaseUrl}${img?.attributes?.url}`);
+      if (!media) return [];
+      if (Array.isArray(media)) {
+        return media.map(getUrl).filter(Boolean);
+      }
+      if (Array.isArray(media.data)) {
+        return media.data.map(getUrl).filter(Boolean);
+      }
+      const url = getUrl(media);
+      return url ? [url] : [];
     };
 
     return {
-      desktopImages: getUrls(attributes?.hero_desktop_image),
-      desktopVideo: getUrl(attributes?.hero_desktop_video),
+      desktopImages: getUrls(hero?.hero_desktop_image),
+      desktopVideo: getUrl(hero?.hero_desktop_video),
     };
   } catch (error) {
-    console.error("Hero section fetch failed:", error);
-    // Return a default structure on error
+    console.error('Hero section fetch failed:', error);
     return {
       desktopImages: ['https://placehold.co/1920x1080/000000/FFF?text=Modern+Architecture'],
       desktopVideo: null,

--- a/src/components/home-client.tsx
+++ b/src/components/home-client.tsx
@@ -30,7 +30,7 @@ export default function HomeClient({ heroData, featuredProperties, testimonials,
     <div className="flex flex-col">
       {/* Hero Section */}
       <section className="relative h-screen w-full overflow-hidden text-white">
-        {/* Background content */}
+        {/* Background content with video > images > placeholder fallback */}
         {heroData.desktopVideo ? (
           <video
             src={heroData.desktopVideo}
@@ -40,14 +40,14 @@ export default function HomeClient({ heroData, featuredProperties, testimonials,
             playsInline
             className="absolute inset-0 w-full h-full object-cover z-0"
           />
-        ) : (
+        ) : heroData.desktopImages.length > 0 ? (
           <Carousel
             className="absolute inset-0 w-full h-full z-0"
             plugins={[Autoplay({ delay: 5000, stopOnInteraction: false })]}
             opts={{ loop: true }}
           >
-            <CarouselContent className="h-full">
-              {(heroData.desktopImages.length > 0 ? heroData.desktopImages : ['https://placehold.co/1920x1080/000000/FFF?text=Modern+Architecture']).map((url, i) => (
+            <CarouselContent className="h-full" containerClassName="h-full">
+              {heroData.desktopImages.map((url, i) => (
                 <CarouselItem key={i} className="relative h-full">
                   <Image
                     src={url}
@@ -60,6 +60,14 @@ export default function HomeClient({ heroData, featuredProperties, testimonials,
               ))}
             </CarouselContent>
           </Carousel>
+        ) : (
+          <Image
+            src="https://placehold.co/1920x1080/000000/FFF?text=Modern+Architecture"
+            alt="Hero placeholder image"
+            fill
+            className="absolute inset-0 w-full h-full object-cover z-0"
+            priority
+          />
         )}
 
         {/* Overlay */}

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -150,14 +150,18 @@ const Carousel = React.forwardRef<
 )
 Carousel.displayName = "Carousel"
 
+type CarouselContentProps = React.HTMLAttributes<HTMLDivElement> & {
+  containerClassName?: string
+}
+
 const CarouselContent = React.forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => {
+  CarouselContentProps
+>(({ className, containerClassName, ...props }, ref) => {
   const { carouselRef, orientation } = useCarousel()
 
   return (
-    <div ref={carouselRef} className="overflow-hidden">
+    <div ref={carouselRef} className={cn("overflow-hidden", containerClassName)}>
       <div
         ref={ref}
         className={cn(


### PR DESCRIPTION
## Summary
- resolve hero section merge conflict and normalize media URL parsing
- ensure hero carousel fills its container so image fallback displays

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689202b213bc8333a16e042a49444309